### PR TITLE
Adds parallel[F] version of async[F]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ scalacOptions += "-Xasync"  // required to enable compiler support
 
 Published for Scala 2.13 and 2.12, cross-build with ScalaJS 1.6. Depends on Cats Effect 3.1.0 or higher.
 
-## Example
+## Example (sequential)
 
 Consider the following program written using a `for`-comprehension (pretend `talkToServer` and `writeToFile` exist and do the obvious things, likely asynchronously):
 
@@ -63,3 +63,25 @@ async[IO] {
 ```
 
 There are no meaningful performance differences between these two encodings. They do almost exactly the same thing using different syntax, similar to how `for`-comprehensions are actually `flatMap` and `map` functions under the surface.
+
+## Example (parallel)
+
+cats-effect-cps also provides syntactic sugar for parallel composition :
+
+```scala
+import cats.effect._
+import cats.effect.cps._
+
+parallel[IO] {
+  getPopulation("Berlin").await + getPopulation("Amsterdam").await
+}
+```
+
+This gets rewritten to roughly this expresion:
+
+```scala
+import cats.effect._
+import cats.syntax.all._
+
+(getPopulation("Paris"), getPopulation("Amsterdam")).parMapN((p, a) => (p + a))
+```

--- a/core/shared/src/main/scala/cats/effect/cps.scala
+++ b/core/shared/src/main/scala/cats/effect/cps.scala
@@ -67,5 +67,18 @@ object cps {
     type F[A] = F0[A]
     def apply[A](body: => A)(implicit F: Async[F]): F[A] = macro AsyncAwaitDsl.asyncImpl[F, A]
   }
+
+  /**
+   * Run the block of code `body` by parallelising all `F`s that are wrapped in "await".
+   * This is translated into a call to `parMapN`.
+   *
+   * Any term (val, var, def) defined in the `parallel` block cannot be used within `await` blocks.
+   */
+  def parallel[F[_]]: PartiallyAppliedParallel[F] = new PartiallyAppliedParallel[F]
+
+  final class PartiallyAppliedParallel[F0[_]] {
+    type F[A] = F0[A]
+    def apply[A](body: => A)(implicit F: Async[F]): F[A] = macro AsyncAwaitDsl.parallelImpl[F, A]
+  }
 }
 


### PR DESCRIPTION
Adds `parallel` version of the `async` method, which translates the block into `F.delay`+   `parMapN` calls. 

The macro attempts to protect against ill-use by preventing any definition in the `parallel` region to be used in its contained `await` calls, as it would prevent the rewrite to `parMapN` from compiling. 