### PR TITLE
 explicit disabling of automatic coloring

### DIFF
--- a/core/shared/src/main/scala-3/cats/effect/cps.scala
+++ b/core/shared/src/main/scala-3/cats/effect/cps.scala
@@ -21,6 +21,7 @@ import _root_.cps.{async, await, CpsAsyncMonad, CpsAwaitable, CpsConcurrentEffec
 import cats.effect.kernel.{Async, Concurrent, Fiber, Sync}
 import cats.effect.kernel.syntax.all._
 
+import scala.annotation.implicitNotFound
 import scala.util.Try
 
 object cps {
@@ -31,10 +32,9 @@ object cps {
     transparent inline def await: A = _root_.cps.await[F, A, F](self)
   }
 
-  implicit def catsEffectCpsMonadPureMemoization[F[_]](implicit F: Concurrent[F]): CpsMonadMemoization.Pure[F] =
-    new CpsMonadMemoization.Pure[F] {
-      def apply[A](fa: F[A]): F[F[A]] = F.memoize(fa)
-    }
+  @implicitNotFound("automatic coloring is disabled")
+  implicit def automaticColoringTag1[F[_]:Concurrent]: _root_.cps.automaticColoring.AutomaticColoringTag[F] = ???
+  implicit def automaticColoringTag2[F[_]:Concurrent]: _root_.cps.automaticColoring.AutomaticColoringTag[F] = ???
 
   // TODO we can actually provide some more gradient instances here
   implicit def catsEffectCpsConcurrentMonad[F[_]](implicit F: Async[F]): CpsConcurrentEffectMonad[F] with CpsMonadInstanceContext[F] =

--- a/core/shared/src/main/scala-3/cats/effect/cps.scala
+++ b/core/shared/src/main/scala-3/cats/effect/cps.scala
@@ -36,6 +36,14 @@ object cps {
   implicit def automaticColoringTag1[F[_]:Concurrent]: _root_.cps.automaticColoring.AutomaticColoringTag[F] = ???
   implicit def automaticColoringTag2[F[_]:Concurrent]: _root_.cps.automaticColoring.AutomaticColoringTag[F] = ???
 
+  // actually not used by dotty-cps-async but need for binary compability with cats-effect-cps 0.4.x.
+  // TODO: remove in 0.5.0
+  implicit def catsEffectCpsMonadPureMemoization[F[_]](implicit F: Concurrent[F]): CpsMonadMemoization.Pure[F] =
+    new CpsMonadMemoization.Pure[F] {
+      def apply[A](fa: F[A]): F[F[A]] = F.memoize(fa)
+    }
+
+
   // TODO we can actually provide some more gradient instances here
   implicit def catsEffectCpsConcurrentMonad[F[_]](implicit F: Async[F]): CpsConcurrentEffectMonad[F] with CpsMonadInstanceContext[F] =
     new CpsConcurrentEffectMonad[F] with CpsMonadInstanceContext[F] {


### PR DESCRIPTION
For some reason (I'm yet not fully understand this, a bug in dotty or something like this - I will investigate now),  
```
summonFrom[cps.automaticColoring.AutomaticColoringTag[F]]
```
 called inside object cats-effect.cps,  resolved to `cps.automaticColoring.tag` even if `cps.automaticColoring.tag` is not imported into the current scope.  This trigger an analysing which trigger a message appearing in https://github.com/typelevel/cats-effect-cps/pull/98

To workaround against this,  better explicitly disable automatic coloring by defining two tags. [I remember you don't want one in your use-case].

Regards!

