### PR TITLE
Update dotty-cps-async to 0.9.21 and sbt-scalajs to 1.16.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 
     libraryDependencies ++= {
       if (tlIsScala3.value)
-        Seq("com.github.rssh" %%% "dotty-cps-async" % "0.9.20")
+        Seq("com.github.rssh" %%% "dotty-cps-async" % "0.9.21")
       else
         Seq("org.scala-lang" % "scala-reflect"   % scalaVersion.value % "provided")
     })

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.typelevel"      % "sbt-typelevel" % "0.4.22")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs" % "1.15.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header" % "5.10.0")


### PR DESCRIPTION
Just wanted to check if dotty-cps-async v0.9.21 compiles without any issues.
Maybe we could do a new release soon?